### PR TITLE
Chore: support for header styles from ThemeData

### DIFF
--- a/doc/theme.md
+++ b/doc/theme.md
@@ -15,7 +15,7 @@ final pdfConverter = PDFConverter(
       fontBold: loader.getFontByName(fontFamily: 'Lora', bold: true),
       fontBoldItalic: loader.getFontByName(fontFamily: 'Lora', bold: true, italic: true),
       fontItalic: loader.getFontByName(fontFamily: 'Lora', italic: true),
-      inherit: true,
+      inherit: tru,e
       lineSpacing: 1.0,
     ),
     header1: pw.TextStyle(
@@ -48,4 +48,4 @@ final pdfConverter = PDFConverter(
 
 #### 🔥 Pdf document result: 
 
-<img src="https://github.com/user-attachments/assets/255525d5-a5a9-4f84-8faf-804510fa8075" style="display: block; margin-left: auto; margin-right: auto; width: 70%"/>
+<img src="https://github.com/user-attachments/assets/4fccefd6-8dbe-44ad-8045-91146c573a04" style="display: block; margin-left: auto; margin-right: auto; width: 70%"/>

--- a/doc/theme.md
+++ b/doc/theme.md
@@ -15,7 +15,7 @@ final pdfConverter = PDFConverter(
       fontBold: loader.getFontByName(fontFamily: 'Lora', bold: true),
       fontBoldItalic: loader.getFontByName(fontFamily: 'Lora', bold: true, italic: true),
       fontItalic: loader.getFontByName(fontFamily: 'Lora', italic: true),
-      inherit: tru,e
+      inherit: true,
       lineSpacing: 1.0,
     ),
     header1: pw.TextStyle(

--- a/doc/theme.md
+++ b/doc/theme.md
@@ -16,7 +16,6 @@ final pdfConverter = PDFConverter(
       fontBoldItalic: loader.getFontByName(fontFamily: 'Lora', bold: true, italic: true),
       fontItalic: loader.getFontByName(fontFamily: 'Lora', italic: true),
       inherit: true,
-      letterSpacing: 1.5,
       lineSpacing: 1.0,
     ),
     header1: pw.TextStyle(

--- a/doc/theme.md
+++ b/doc/theme.md
@@ -15,7 +15,6 @@ final pdfConverter = PDFConverter(
       fontBold: loader.getFontByName(fontFamily: 'Lora', bold: true),
       fontBoldItalic: loader.getFontByName(fontFamily: 'Lora', bold: true, italic: true),
       fontItalic: loader.getFontByName(fontFamily: 'Lora', italic: true),
-      inherit: true,
       lineSpacing: 1.0,
     ),
     header1: pw.TextStyle(
@@ -25,7 +24,6 @@ final pdfConverter = PDFConverter(
       fontBold: loader.getFontByName(fontFamily: 'Lora', bold: true),
       fontBoldItalic: loader.getFontByName(fontFamily: 'Lora', bold: true, italic: true),
       fontItalic: loader.getFontByName(fontFamily: 'Lora', italic: true),
-      inherit: true,
       letterSpacing: 1.5,
       lineSpacing: 1.0,
     ),
@@ -36,7 +34,6 @@ final pdfConverter = PDFConverter(
       fontBold: loader.getFontByName(fontFamily: 'Lora', bold: true),
       fontBoldItalic: loader.getFontByName(fontFamily: 'Lora', bold: true, italic: true),
       fontItalic: loader.getFontByName(fontFamily: 'Lora', italic: true),
-      inherit: true,
       letterSpacing: 1.5,
       lineSpacing: 1.0,
     ),

--- a/doc/theme.md
+++ b/doc/theme.md
@@ -15,6 +15,7 @@ final pdfConverter = PDFConverter(
       fontBold: loader.getFontByName(fontFamily: 'Lora', bold: true),
       fontBoldItalic: loader.getFontByName(fontFamily: 'Lora', bold: true, italic: true),
       fontItalic: loader.getFontByName(fontFamily: 'Lora', italic: true),
+      inherit: true,
       lineSpacing: 1.0,
     ),
     header1: pw.TextStyle(
@@ -24,6 +25,7 @@ final pdfConverter = PDFConverter(
       fontBold: loader.getFontByName(fontFamily: 'Lora', bold: true),
       fontBoldItalic: loader.getFontByName(fontFamily: 'Lora', bold: true, italic: true),
       fontItalic: loader.getFontByName(fontFamily: 'Lora', italic: true),
+      inherit: true,
       letterSpacing: 1.5,
       lineSpacing: 1.0,
     ),
@@ -34,6 +36,7 @@ final pdfConverter = PDFConverter(
       fontBold: loader.getFontByName(fontFamily: 'Lora', bold: true),
       fontBoldItalic: loader.getFontByName(fontFamily: 'Lora', bold: true, italic: true),
       fontItalic: loader.getFontByName(fontFamily: 'Lora', italic: true),
+      inherit: true,
       letterSpacing: 1.5,
       lineSpacing: 1.0,
     ),

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -4,14 +4,13 @@ class Constant {
   static const double kDefaultLineHeight = 1.0;
   static const int DEFAULT_FONT_SIZE = 12;
   static const String DEFAULT_FONT_FAMILY = 'Arial';
-  // to encode markdown characters to avoid detection
   static const List<double> kDefaultHeadingSizes = <double>[
-    37,
-    34,
     28,
-    24,
-    20,
-    17
+    25,
+    23,
+    21,
+    18,
+    15,
   ];
   @Deprecated(
       'IMAGE_LOCAL_STORAGE_PATH_PATTERN is no longer used. You can use localStorageImageAndroidPattern or localStorageImageUniversalPattern instead')

--- a/lib/src/core/pdf_configurator.dart
+++ b/lib/src/core/pdf_configurator.dart
@@ -315,7 +315,8 @@ abstract class PdfConfigurator<T, D> extends ConverterConfigurator<T, D>
     if (headerLevel != null && headerLevel > 0) {
       final double headerFontSize = headerLevel.resolveHeaderLevel(
           headingSizes: customHeadingSizes ?? Constant.kDefaultHeadingSizes);
-      finalStyle = finalStyle.copyWith(fontSize: headerFontSize);
+      finalStyle = getHeaderStyle(headerLevel) ??
+          finalStyle.copyWith(fontSize: headerFontSize);
     }
 
     // we cannot build inline code in a code-block because
@@ -452,6 +453,18 @@ abstract class PdfConfigurator<T, D> extends ConverterConfigurator<T, D>
       ),
     );
     return widget;
+  }
+
+  @protected
+  pw.TextStyle? getHeaderStyle(int level) {
+    if (level > 0 && level <= 5) {
+      if (level == 1) return defaultTheme.header1;
+      if (level == 2) return defaultTheme.header2;
+      if (level == 3) return defaultTheme.header3;
+      if (level == 4) return defaultTheme.header4;
+      if (level == 5) return defaultTheme.header5;
+    }
+    return null;
   }
 
   @protected

--- a/lib/src/core/pdf_service/pdf_service.dart
+++ b/lib/src/core/pdf_service/pdf_service.dart
@@ -503,14 +503,21 @@ class PdfService extends PdfConfigurator<Delta, pw.Document> {
     bool addFontSize = true;
     final double? lineHeight = blockAttributes?['line-height'];
     if (blockAttributes?['header'] != null) {
+      addFontSize = false;
       final int headerLevel = blockAttributes!['header'];
+      final pw.TextStyle? headerStyle =
+          headerLevel > 5 ? null : getHeaderStyle(headerLevel);
+      // if the header level is into the range of the headers supported by ThemeData
+      // the return it
+      if (headerStyle != null) return (headerStyle, addFontSize);
+      // but, if it is out of the range, get the default styles and
+      // apply just the correct font size for the header
       final double currentFontSize = headerLevel.resolveHeaderLevel(
           headingSizes: customHeadingSizes ?? Constant.kDefaultHeadingSizes);
       pw.TextStyle style = defaultTheme.defaultTextStyle.copyWith(
         fontSize: currentFontSize,
         lineSpacing: lineHeight?.resolveLineHeight(),
       );
-      addFontSize = false;
       return (style, addFontSize);
     } else if (blockAttributes?['code-block'] != null) {
       pw.TextStyle style =


### PR DESCRIPTION
## Description

Previously, even if we passed the `header0`, `header1`, `header2`, `header3`, `header4` or `header5` parameters to the `ThemeData` via the `PDFConverter`, they were never applied.

The `defaultTextStyle` was always used as the base.

With this change, full support is added to be able to use these parameters from the `ThemeData` without them being modified (i.e. they are used as is and are not merged with the attributes of the `defaultTextStyle`).

## Example of how this change improve the styles

Using this code:

```dart
final pdfConverter = PDFConverter(
  themeData: pw.ThemeData(
    defaultTextStyle: pw.TextStyle(
      color: PdfColor.fromInt(0xFF555555),
      fontNormal: loader.getFontByName(fontFamily: 'Lora'),
      fontBold: loader.getFontByName(fontFamily: 'Lora', bold: true),
      fontBoldItalic: loader.getFontByName(fontFamily: 'Lora', bold: true, italic: true),
      fontItalic: loader.getFontByName(fontFamily: 'Lora', italic: true),
      inherit: true,
      letterSpacing: 1.5,
      lineSpacing: 1.0,
    ),
    header1: pw.TextStyle(
      fontSize: 27,
      color: PdfColor.fromInt(0xFF555555),
      fontNormal: loader.getFontByName(fontFamily: 'Lora'),
      fontBold: loader.getFontByName(fontFamily: 'Lora', bold: true),
      fontBoldItalic: loader.getFontByName(fontFamily: 'Lora', bold: true, italic: true),
      fontItalic: loader.getFontByName(fontFamily: 'Lora', italic: true),
      inherit: true,
      letterSpacing: 1.5,
      lineSpacing: 1.0,
    ),
    header2: pw.TextStyle(
      fontSize: 24,
      color: PdfColor.fromInt(0xFF555555),
      fontNormal: loader.getFontByName(fontFamily: 'Lora'),
      fontBold: loader.getFontByName(fontFamily: 'Lora', bold: true),
      fontBoldItalic: loader.getFontByName(fontFamily: 'Lora', bold: true, italic: true),
      fontItalic: loader.getFontByName(fontFamily: 'Lora', italic: true),
      inherit: true,
      letterSpacing: 1.5,
      lineSpacing: 1.0,
    ),
  ),
  document: _quillController.document.toDelta(),
  pageFormat: params,
);
```

### Generate this, before the change

_As we say, only `defaultTextStyle` param, is used to be applied to all paragraphs (even the headers)._

![Captura de pantalla_2025-03-06_13-42-01](https://github.com/user-attachments/assets/a4abbdbf-b41e-4970-b219-156829bcefc8)

### Generate this, after the apply the change

_Here we removes the `letterSpacing: 1.5` param to show how the styles between headers and default paragraphs are different._

![Captura de pantalla_2025-03-06_14-06-59](https://github.com/user-attachments/assets/4fccefd6-8dbe-44ad-8045-91146c573a04)