### PR TITLE
Fix: pageBuilder is not being passed correctly to PdfService class

### DIFF
--- a/lib/src/converter/pdf_converter.dart
+++ b/lib/src/converter/pdf_converter.dart
@@ -319,7 +319,7 @@ class PDFConverter {
         fonts: globalFontsFallbacks,
         customTheme: themeData,
         directionality: textDirection.toPdf(),
-        pageBuilder: null,
+        pageBuilder: pageBuilder,
         isWeb: isWeb,
         enableCodeBlockHighlighting: enableCodeBlockHighlighting,
         isLightCodeBlockTheme: isLightCodeBlockTheme,


### PR DESCRIPTION
## Description

Fixed an issue where `pageBuilder` would never work or would be ignored. This was due to it not being passed to the `PdfService` correctly.