### PR TITLE
Fix: zapfDingBats is not being added to the fonts

### DIFF
--- a/lib/src/converter/pdf_converter.dart
+++ b/lib/src/converter/pdf_converter.dart
@@ -227,6 +227,7 @@ class PDFConverter {
       pw.Font.helveticaBold(),
       pw.Font.helveticaOblique(),
       pw.Font.symbol(),
+      pw.Font.zapfDingbats(),
       pw.Font.times(),
       pw.Font.timesBold(),
       pw.Font.timesItalic(),


### PR DESCRIPTION
## Description

Fixed an issue where certain special characters were not rendered because the `zapfDingBats` font, which is responsible for these characters, was not added.

* Fix: *https://github.com/CatHood0/flutter_quill_to_pdf/issues/21#issuecomment-2708805939*