### PR TITLE
Feat: support for apply striketrough style on checked elements and customize them

### DIFF
--- a/example/.metadata
+++ b/example/.metadata
@@ -4,7 +4,7 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "35c388afb57ef061d06a39b537336c87e0e3d1b1"
+  revision: "b25305a8832cfc6ba632a7f87ad455e319dccce8"
   channel: "stable"
 
 project_type: app
@@ -13,26 +13,26 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
-      base_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
+      create_revision: b25305a8832cfc6ba632a7f87ad455e319dccce8
+      base_revision: b25305a8832cfc6ba632a7f87ad455e319dccce8
     - platform: android
-      create_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
-      base_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
+      create_revision: b25305a8832cfc6ba632a7f87ad455e319dccce8
+      base_revision: b25305a8832cfc6ba632a7f87ad455e319dccce8
     - platform: ios
-      create_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
-      base_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
+      create_revision: b25305a8832cfc6ba632a7f87ad455e319dccce8
+      base_revision: b25305a8832cfc6ba632a7f87ad455e319dccce8
     - platform: linux
-      create_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
-      base_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
+      create_revision: b25305a8832cfc6ba632a7f87ad455e319dccce8
+      base_revision: b25305a8832cfc6ba632a7f87ad455e319dccce8
     - platform: macos
-      create_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
-      base_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
+      create_revision: b25305a8832cfc6ba632a7f87ad455e319dccce8
+      base_revision: b25305a8832cfc6ba632a7f87ad455e319dccce8
     - platform: web
-      create_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
-      base_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
+      create_revision: b25305a8832cfc6ba632a7f87ad455e319dccce8
+      base_revision: b25305a8832cfc6ba632a7f87ad455e319dccce8
     - platform: windows
-      create_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
-      base_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
+      create_revision: b25305a8832cfc6ba632a7f87ad455e319dccce8
+      base_revision: b25305a8832cfc6ba632a7f87ad455e319dccce8
 
   # User provided section
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -107,6 +107,11 @@ class _MyHomePageState extends State<MyHomePage> {
                   frontMatterDelta: null,
                   isWeb: kIsWeb,
                   onDetectImageUrl: kIsWeb ? _fetchBlobAsBytes : null,
+                  paintStrikethoughStyleOnCheckedElements: true,
+                  checkboxDecorator: CheckboxDecorator.base(
+                    strikethroughColor: "#AAAAAA",
+                    italicOnStrikethrough: true,
+                  ),
                   document: _quillController.document.toDelta(),
                   fallbacks: [...loader.allFonts()],
                   onRequestFontFamily: (FontFamilyRequest familyRequest) {

--- a/lib/flutter_quill_to_pdf.dart
+++ b/lib/flutter_quill_to_pdf.dart
@@ -11,6 +11,7 @@ export 'package:flutter_quill_to_pdf/src/core/request/font_family_request.dart';
 export 'package:flutter_quill_to_pdf/src/core/document_options.dart';
 export 'package:flutter_quill_to_pdf/src/core/enums/list_type_widget.dart';
 export 'package:flutter_quill_to_pdf/src/core/response/font_family_response.dart';
+export 'package:flutter_quill_to_pdf/src/core/decorators/checkbox_decorator.dart';
 //converter options
 export 'package:flutter_quill_to_pdf/src/core/highlight_utils/hightlight_themes.dart';
 export 'package:flutter_quill_to_pdf/src/core/converter_option/pdf_page_format.dart';

--- a/lib/src/converter/pdf_converter.dart
+++ b/lib/src/converter/pdf_converter.dart
@@ -3,6 +3,7 @@ import 'dart:ui' as ui;
 import 'package:dart_quill_delta/dart_quill_delta.dart';
 import 'package:flutter_quill_delta_easy_parser/flutter_quill_delta_easy_parser.dart'
     as ep;
+import 'package:flutter_quill_to_pdf/src/core/decorators/checkbox_decorator.dart';
 import 'package:flutter_quill_to_pdf/src/core/delta_processor/delta_attributes_options.dart';
 import 'package:flutter_quill_to_pdf/src/core/document_options.dart';
 import 'package:flutter_quill_to_pdf/src/core/enums/list_type_widget.dart';
@@ -170,6 +171,18 @@ class PDFConverter {
   @experimental
   final List<double>? customHeadingSizes;
 
+  /// Determines if the elements of check lists
+  /// will be painted with ~strikethough style~ when
+  /// checked is `true`
+  @experimental
+  final bool paintStrikethoughStyleOnCheckedElements;
+
+  /// Determines the appareance of the checkbox leading widget
+  ///
+  /// _Can be ignored, since is configured by default_
+  @experimental
+  final CheckboxDecorator? checkboxDecorator;
+
   /// [isWeb] is used to know is the current platform is web since the way of the fetch images files
   /// is different from the other platforms
   @experimental
@@ -178,6 +191,8 @@ class PDFConverter {
   PDFConverter({
     required this.pageFormat,
     required this.document,
+    @experimental this.checkboxDecorator,
+    @experimental this.paintStrikethoughStyleOnCheckedElements = false,
     @experimental this.documentOptions = const DocumentOptions(),
     @experimental this.enableCodeBlockHighlighting = true,
     @experimental this.customHeadingSizes,
@@ -321,6 +336,9 @@ class PDFConverter {
         pageBuilder,
   ) =>
       qpdf.PdfService(
+        paintStrikethoughStyleOnCheckedElements:
+            paintStrikethoughStyleOnCheckedElements,
+        checkboxDecorator: checkboxDecorator ?? CheckboxDecorator.base(),
         pageFormat: pageFormat,
         fonts: globalFontsFallbacks,
         customTheme: themeData,

--- a/lib/src/core/decorators/checkbox_decorator.dart
+++ b/lib/src/core/decorators/checkbox_decorator.dart
@@ -1,0 +1,59 @@
+import 'package:meta/meta.dart';
+import 'package:pdf/pdf.dart';
+import 'package:pdf/widgets.dart';
+
+import '../../extensions/pdf_extension.dart';
+
+/// This class determines how will look the leading
+/// appearance
+@immutable
+class CheckboxDecorator {
+  final BoxDecoration? decoration;
+  final double width;
+  final double height;
+  final bool tristate;
+
+  /// Determines the hex color of the checkbox
+  final String color;
+
+  /// Determines the color (in hex format) of the text and the strikethrough
+  /// decoration of the element
+  final String? strikethroughColor;
+
+  /// Determines if the elements that are
+  /// checked, will be forcely applying
+  /// italic style
+  final bool italicOnStrikethrough;
+
+  static const String white = '#FFFFFF';
+
+  const CheckboxDecorator({
+    required this.width,
+    required this.height,
+    required this.decoration,
+    required this.tristate,
+    required this.color,
+    this.strikethroughColor,
+    this.italicOnStrikethrough = true,
+  });
+
+  const CheckboxDecorator.base({
+    this.width = 13,
+    this.height = 13,
+    this.decoration,
+    this.tristate = false,
+    this.color = white,
+    this.strikethroughColor,
+    this.italicOnStrikethrough = true,
+  });
+
+  PdfColor get checkcolor => hexToColor(
+        color,
+      );
+
+  PdfColor? get strikeColor => strikethroughColor == null
+      ? null
+      : hexToColor(
+          strikethroughColor!,
+        );
+}

--- a/lib/src/core/pdf_service/pdf_service.dart
+++ b/lib/src/core/pdf_service/pdf_service.dart
@@ -31,11 +31,13 @@ class PdfService extends PdfConfigurator<Delta, pw.Document> {
       PdfPageFormat pageFormat)? pageBuilder;
 
   PdfService({
+    required super.paintStrikethoughStyleOnCheckedElements,
     required PDFPageFormat pageFormat,
     required List<pw.Font> fonts,
     required this.documentOptions,
     this.pageBuilder,
     this.iconsFont,
+    super.checkboxDecorator,
     super.imageConstraints,
     super.onDetectImageUrl,
     super.directionality,


### PR DESCRIPTION
## Description

Now we can customize the checkboxes elements using `CheckboxDecorator` class in `PDFConverter` constructor parameters.

> [!IMPORTANT]
> `paintStrikethoughStyleOnCheckedElements` must be **`true`** to allow to the `PDFConverter` apply `strikethroughColor` and `italicOnStrikethrough`.

Something like this code:

```dart
PDFConverter pdfConverter = PDFConverter(
  paintStrikethoughStyleOnCheckedElements: true,
  checkboxDecorator: CheckboxDecorator.base(
    strikethroughColor: "#AAAAAA",
    italicOnStrikethrough: true,
  ),
  document: _quillController.document.toDelta(),
);
```

You can get a checkbox like:

<img width="903" height="485" alt="Captura de pantalla_2025-07-25_14-31-31" src="https://github.com/user-attachments/assets/88095313-e917-4e42-8b87-bc422051b4c5" />


## Related Issues

* Fix: https://github.com/CatHood0/flutter_quill_to_pdf/issues/35#issuecomment-3115746126

## Type of Change

- [x] ✨ **Feature:** New functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [x] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
